### PR TITLE
Update README + re-add cv to Composer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
   - package-ecosystem: composer
     directory: /
     schedule:
-      interval: daily
+      interval: weekly

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-Update `composer.json`, then update the lockfile in Docker with the following:
+# Snowdrift CiviCRM Dependency Configuration
+
+## Automatic updates
+
+This repo has Dependabot configured for weekly automatic updates. Simply merge the generated PR and Chef will deploy the update on the next run.
+
+## Manual updates
+
+Update `composer.json`, then update the lockfile with the following Docker container:
 
 ```sh
 # Build container

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "civicrm/civicrm-core": "~5.41",
         "civicrm/civicrm-drupal-8": "~5.41",
         "civicrm/civicrm-packages": "~5.41",
+        "civicrm/cv": "~0.3",
         "composer/installers": "~1.9",
         "drupal/core-composer-scaffold": "~9.2",
         "drupal/core-project-message": "~9.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "768f4a9c5b74b02b984327e3693d31e2",
+    "content-hash": "cb46f98006850ec21d3288fe6e41c88e",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -1199,6 +1199,63 @@
                 "source": "https://github.com/civicrm/composer-downloads-plugin/tree/v3.0.1"
             },
             "time": "2020-11-02T05:26:23+00:00"
+        },
+        {
+            "name": "civicrm/cv",
+            "version": "v0.3.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/civicrm/cv.git",
+                "reference": "d546c0cfae2e9fb16288e5a810847a7ae7fdc7f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/civicrm/cv/zipball/d546c0cfae2e9fb16288e5a810847a7ae7fdc7f6",
+                "reference": "d546c0cfae2e9fb16288e5a810847a7ae7fdc7f6",
+                "shasum": ""
+            },
+            "require": {
+                "civicrm/composer-downloads-plugin": "~2.1|^3",
+                "php": ">=7.1.3",
+                "psy/psysh": "@stable",
+                "symfony/console": "^4",
+                "symfony/filesystem": "^4",
+                "symfony/process": "^4"
+            },
+            "bin": [
+                "bin/cv"
+            ],
+            "type": "library",
+            "extra": {
+                "downloads": {
+                    "box": {
+                        "url": "https://github.com/humbug/box/releases/download/3.8.4/box.phar",
+                        "path": "bin/box",
+                        "type": "phar"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Civi\\Cv\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tim Otten",
+                    "email": "totten@civicrm.org"
+                }
+            ],
+            "description": "CLI tool for CiviCRM",
+            "support": {
+                "issues": "https://github.com/civicrm/cv/issues",
+                "source": "https://github.com/civicrm/cv/tree/v0.3.14"
+            },
+            "time": "2021-12-08T01:58:30+00:00"
         },
         {
             "name": "composer/installers",


### PR DESCRIPTION
Adds Dependabot PR instructions to README as per https://github.com/osuosl-cookbooks/proj-snowdrift/issues/79.

Installs of this were broken with the move to Drupal 9 (c62c4ba). A fix for this has been merged upstream (https://github.com/civicrm/cv/pull/103) and it can now be installed through Composer again.