### PR TITLE
Bump Drupal core to 10.6.14 and set minimum-stability stable (6 security fixes)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "conflict": {
         "drupal/drupal": "*"
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "config": {
         "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bb56202e2c42b453c7d4692bc5eb1522",
+    "content-hash": "a75634d077f81b9f2d3570f6a8279681",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -2727,16 +2727,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "10.6.12",
+            "version": "10.6.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "87fd33ee009619bcd0a1679d6015c349f74dd977"
+                "reference": "d7476043e931569bd584982e4bdd453900ac1620"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/87fd33ee009619bcd0a1679d6015c349f74dd977",
-                "reference": "87fd33ee009619bcd0a1679d6015c349f74dd977",
+                "url": "https://api.github.com/repos/drupal/core/zipball/d7476043e931569bd584982e4bdd453900ac1620",
+                "reference": "d7476043e931569bd584982e4bdd453900ac1620",
                 "shasum": ""
             },
             "require": {
@@ -2886,13 +2886,13 @@
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
             "support": {
-                "source": "https://github.com/drupal/core/tree/10.6.12"
+                "source": "https://github.com/drupal/core/tree/10.6.14"
             },
-            "time": "2026-06-23T07:23:10+00:00"
+            "time": "2026-07-23T00:19:22+00:00"
         },
         {
             "name": "drupal/core-composer-scaffold",
-            "version": "10.6.13",
+            "version": "10.6.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-composer-scaffold.git",
@@ -2936,13 +2936,13 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-composer-scaffold/tree/10.6.13"
+                "source": "https://github.com/drupal/core-composer-scaffold/tree/10.6.14"
             },
             "time": "2024-08-22T14:31:30+00:00"
         },
         {
             "name": "drupal/core-project-message",
-            "version": "10.6.13",
+            "version": "10.6.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-project-message.git",
@@ -2983,16 +2983,16 @@
         },
         {
             "name": "drupal/core-recommended",
-            "version": "10.6.12",
+            "version": "10.6.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-recommended.git",
-                "reference": "d11d79225bf6f0ce2f17cd29daf96ec625ec5a63"
+                "reference": "d434d11aa1622471002566202deab6c309fd0606"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/d11d79225bf6f0ce2f17cd29daf96ec625ec5a63",
-                "reference": "d11d79225bf6f0ce2f17cd29daf96ec625ec5a63",
+                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/d434d11aa1622471002566202deab6c309fd0606",
+                "reference": "d434d11aa1622471002566202deab6c309fd0606",
                 "shasum": ""
             },
             "require": {
@@ -3000,11 +3000,11 @@
                 "composer/semver": "~3.4.4",
                 "doctrine/deprecations": "~1.1.5",
                 "doctrine/lexer": "~2.1.1",
-                "drupal/core": "10.6.12",
+                "drupal/core": "10.6.14",
                 "egulias/email-validator": "~4.0.4",
-                "guzzlehttp/guzzle": "~7.12.1",
-                "guzzlehttp/promises": "~2.5.0",
-                "guzzlehttp/psr7": "~2.12.1",
+                "guzzlehttp/guzzle": "~7.15.1",
+                "guzzlehttp/promises": "~2.5.1",
+                "guzzlehttp/psr7": "~2.13.0",
                 "masterminds/html5": "~2.10.0",
                 "mck89/peast": "~v1.17.4",
                 "pear/archive_tar": "~1.6.0",
@@ -3060,9 +3060,9 @@
             ],
             "description": "Core and its dependencies with known-compatible minor versions. Require this project INSTEAD OF drupal/core.",
             "support": {
-                "source": "https://github.com/drupal/core-recommended/tree/10.6.12"
+                "source": "https://github.com/drupal/core-recommended/tree/10.6.14"
             },
-            "time": "2026-06-23T07:23:10+00:00"
+            "time": "2026-07-23T00:19:22+00:00"
         },
         {
             "name": "drupal/seven",
@@ -3576,22 +3576,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.12.x-dev",
+            "version": "7.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "9aa17bcdd777ee31df9fc83c337ca4ca2340def3"
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/9aa17bcdd777ee31df9fc83c337ca4ca2340def3",
-                "reference": "9aa17bcdd777ee31df9fc83c337ca4ca2340def3",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.5",
-                "guzzlehttp/psr7": "^2.12.3",
+                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/psr7": "^2.13",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
@@ -3603,8 +3603,8 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.5.1",
+                "guzzle/client-integration-tests": "3.0.3",
+                "guzzlehttp/test-server": "^0.7",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -3684,7 +3684,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.12"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
             },
             "funding": [
                 {
@@ -3700,7 +3700,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-23T15:29:02+00:00"
+            "time": "2026-07-18T11:23:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -3788,16 +3788,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.12.5",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "9365d578a9fd1552ad6ca9c3cb530708526feb09"
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9365d578a9fd1552ad6ca9c3cb530708526feb09",
-                "reference": "9365d578a9fd1552ad6ca9c3cb530708526feb09",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
                 "shasum": ""
             },
             "require": {
@@ -3887,7 +3887,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.12.5"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
             },
             "funding": [
                 {
@@ -3903,7 +3903,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-13T01:27:20+00:00"
+            "time": "2026-07-16T22:23:49+00:00"
         },
         {
             "name": "knplabs/knp-snappy",
@@ -4630,16 +4630,16 @@
         },
         {
             "name": "mck89/peast",
-            "version": "v1.17.6",
+            "version": "v1.17.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mck89/peast.git",
-                "reference": "b8b4184b1e6912669f9af155caef9050509d9f18"
+                "reference": "89ee39f81e82cb7ed36cc5abaf2edd43cef71770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mck89/peast/zipball/b8b4184b1e6912669f9af155caef9050509d9f18",
-                "reference": "b8b4184b1e6912669f9af155caef9050509d9f18",
+                "url": "https://api.github.com/repos/mck89/peast/zipball/89ee39f81e82cb7ed36cc5abaf2edd43cef71770",
+                "reference": "89ee39f81e82cb7ed36cc5abaf2edd43cef71770",
                 "shasum": ""
             },
             "require": {
@@ -4652,7 +4652,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.17.6-dev"
+                    "dev-master": "1.17.7-dev"
                 }
             },
             "autoload": {
@@ -4673,9 +4673,9 @@
             "description": "Peast is PHP library that generates AST for JavaScript code",
             "support": {
                 "issues": "https://github.com/mck89/peast/issues",
-                "source": "https://github.com/mck89/peast/tree/v1.17.6"
+                "source": "https://github.com/mck89/peast/tree/v1.17.7"
             },
-            "time": "2026-04-24T08:04:05+00:00"
+            "time": "2026-07-21T11:56:06+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -11243,7 +11243,7 @@
     ],
     "packages-dev": [],
     "aliases": [],
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,


### PR DESCRIPTION
## Summary

Resolves **all 6 outstanding security advisories**. `composer audit --locked` is now clean (exit 1 only from the abandoned `pear/net_socket`, which CiviCRM requires).

### The 4 open Dependabot guzzle alerts (#110–#113)

These were blocked by `drupal/core-recommended` ≤10.6.13, which pinned `guzzlehttp/guzzle ~7.12.1` and `guzzlehttp/psr7 ~2.12.1`, while the fixes require guzzle 7.14.2/7.15.1 and psr7 `^2.13`. Guzzle shipped **no backport** to the 7.12 branch, so no version inside the old pin fixed anything — bumping to 10.6.13 moved guzzle not at all.

Drupal **10.6.14** repins to `~7.15.1` ([#3612247](https://www.drupal.org/project/drupal/issues/3612247)), so no workaround was needed:

| Package | Before | After |
|---|---|---|
| `guzzlehttp/guzzle` | 7.12.x-dev | **7.15.1** |
| `guzzlehttp/psr7` | 2.12.5 | **2.13.0** |

Fixes: proxy-authorization header leak to origin servers, host-only cookie scope not preserved, unbounded response cookies (DoS), URI fragments disclosed in redirect `Referer`.

### 2 Drupal core advisories Dependabot never reported

`composer audit` surfaced two **moderately critical** advisories invisible to Dependabot, because drupal.org's security feed is not in the GitHub Advisory Database:

| Advisory | CVE | Type |
|---|---|---|
| [SA-CORE-2026-012](https://www.drupal.org/sa-core-2026-012) | CVE-2026-55805 | Cross-site scripting |
| [SA-CORE-2026-010](https://www.drupal.org/sa-core-2026-010) | CVE-2026-15916 | Information disclosure |

`drupal/core(-recommended)` 10.6.12 → **10.6.14** fixes both.

### `minimum-stability`: dev → stable

The `dev` setting made branch refs eligible tree-wide, parking guzzle on a `7.12.x-dev` label. Composer's advisory ranges don't match branch aliases, so the solver's security blocker was being **silently bypassed**. The lock now has zero dev-versioned packages and an empty `stability-flags` map.

## Notes

- Lockfile regenerated via the documented Docker/PHP 8.1 procedure.
- `core-recommended`'s pinning is retained — `twig/twig` correctly stays at 3.27.1.

## Follow-up suggestion

Add `composer audit --locked` as a gating CI step — it catches the drupal.org advisory feed that Dependabot structurally cannot. Gate on the `advisories` field rather than the exit code, since the abandoned `pear/net_socket` keeps exit status at 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)